### PR TITLE
Update from python3.10 to 3.11

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add git
 RUN git clone https://github.com/trufflesecurity/trufflehog.git trufflehog 
 RUN cd trufflehog ; go build -o trufflehog
 
-FROM python:3.10-alpine as base
+FROM python:3.11-alpine as base
 FROM base as builder
 RUN apk add build-base
 RUN mkdir /install
@@ -23,4 +23,4 @@ ENV PYTHONPATH=/app
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app
-CMD ["python3", "/app/agent/trufflehog_agent.py"]
+CMD ["python3.11", "/app/agent/trufflehog_agent.py"]

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: trufflehog
-version: 0.3.6
+version: 0.3.7
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [trufflehog tool] https://github.com/trufflesecurity/trufflehog by trufflesecurity.
 


### PR DESCRIPTION
**Update from python3.10 to 3.11:**

Steps:
- update python-version in .github/workflows/pylint.yml
- update python-version in .github/workflows/pytest.yml
- update python-version in docker file

Steps to test the new version:

- run unit tests using python 3.11 in virtual env

```bash
virtualenv -p python3.11 venv
source venv/bin/activate
pip install -r requirement.txt
pip install -r tests/test-requirement.txt

mypy agent/ tests/
black .
pylint --rcfile=.pylintrc --ignore=tests/ agent/
pylint --rcfile=.pylintrc -d C0103,W0613 tests/
pytest
```

- run test after building the docker image

```bash
ostorlab agent build -f ostorlab.yaml -o dev --no-cache
ostorlab scan run --install --follow=agent/dev/trufflehog --agent agent/dev/trufflehog file --file tests/keys
```