### PR TITLE
Remove non-critical debugs from trufflehog

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -93,7 +93,7 @@ class TruffleHogAgent(
         Returns:
             None.
         """
-        logger.info("Processing input and Starting trufflehog.")
+        logger.debug("Processing input and Starting trufflehog.")
 
         cmd_output = None
         if message.selector.startswith("v3.asset.link"):
@@ -123,7 +123,7 @@ class TruffleHogAgent(
         if cmd_output is None:
             return
 
-        logger.info("Parsing trufflehog output.")
+        logger.debug("Parsing trufflehog output.")
 
         secrets = self._process_scanner_output(cmd_output)
 

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -1,8 +1,9 @@
 """Unittest for truflehog agent."""
 
-from typing import Dict
 import logging
+from typing import Dict
 
+import pytest
 from ostorlab.agent.message import message
 from pytest_mock import plugin
 
@@ -200,7 +201,7 @@ def testTrufflehog_whenProcessingSecrets_shouldLogNonCriticalMessagesAtDebugLeve
     agent_persist_mock: Dict[str | bytes, str | bytes],
     mocker: plugin.MockerFixture,
     agent_mock: list[message.Message],
-    caplog,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Tests that non-critical messages are logged at debug level."""
 

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -202,7 +202,7 @@ def testTrufflehog_whenProcessingSecrets_shouldLogNonCriticalMessagesAtDebugLeve
     agent_mock: list[message.Message],
     caplog,
 ) -> None:
-    """Tests running the agent on a file and parsing the json output."""
+    """Tests that non-critical messages are logged at debug level."""
 
     mocker.patch(
         "subprocess.check_output",


### PR DESCRIPTION
## Switching Non-critical Logs From Info To Debug

![image](https://github.com/user-attachments/assets/7ea95b6d-3e0b-4048-ba00-b2d69cb65bad)


[Ticket-os-13302](https://report.ostorlab.co/remediation/tickets/os-13302)

