### PR TITLE
Switch trufflehog useless logs from info to debug.

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -93,7 +93,7 @@ class TruffleHogAgent(
         Returns:
             None.
         """
-        logger.info("Processing input and Starting trufflehog.")
+        logger.debug("Processing input and Starting trufflehog.")
 
         cmd_output = None
         if message.selector.startswith("v3.asset.link"):
@@ -107,7 +107,7 @@ class TruffleHogAgent(
             content = message.data.get("content", b"")
             file_type = utils.get_file_type(filename=path, file_content=content)
             if file_type in BLACKLISTED_FILE_TYPES:
-                logger.info(
+                logger.debug(
                     "Skipping file %s with blacklisted type %s", path, file_type
                 )
                 return
@@ -123,7 +123,7 @@ class TruffleHogAgent(
         if cmd_output is None:
             return
 
-        logger.info("Parsing trufflehog output.")
+        logger.debug("Parsing trufflehog output.")
 
         secrets = self._process_scanner_output(cmd_output)
 


### PR DESCRIPTION
Switch trufflehog useless logs from info to debug.
trufflehog proccess **a lot** of files, and the logs is usless.
## Ticket: https://report.ostorlab.co/remediation/tickets/os-13302
![image](https://github.com/user-attachments/assets/a1572b34-1c3b-48c2-9265-57ce01127727)
