### PR TITLE
Bump image version because of compatibility issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as scanner
+FROM golang:1.23-alpine as scanner
 RUN mkdir /install
 WORKDIR /install
 RUN apk add git


### PR DESCRIPTION
## Bump golang image version

Agent TruffleHog build is failing because of dependency issues, as the latest version of the project requires go:1.23

![image](https://github.com/user-attachments/assets/85ce246f-d7aa-4da8-a747-49b4ae32f80b)

**Image from TruffleHog's official repository**:

![image](https://github.com/user-attachments/assets/9c7f9c2b-9439-4cc7-8a01-1984b80e2678)

