### PR TITLE
Augment rules with metadata about their location.

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -44,7 +44,9 @@ def _prepare_vulnerability_location(
     message: m.Message,
     file_path: str,
 ) -> vuln_mixin.VulnerabilityLocation | None:
-    """Prepare a `VulnerabilityLocation` instance with iOS asset & its Bundle ID, with file path as vulnerability metadata."""
+    """Prepare a `VulnerabilityLocation` instance with file path as vulnerability metadata and
+    iOS/Android asset & their respective bundle-ID/package name as asset metadata.
+    """
     package_name = message.data.get("android_metadata", {}).get("package_name")
     bundle_id = message.data.get("ios_metadata", {}).get("bundle_id")
     if bundle_id is None and package_name is None:


### PR DESCRIPTION
**What:** Part of the Ostorlab Security Scanner Github application, This PR adds information about the file where the findings was detected as metadata.
**Why:** Because we needed information about the file to be able to map it to the file path on the Pull Request raw code on Github.
**How:** Create instances of `VulnerabilityLocation`, where the metadata list contains an element with type `FILE_PATH` & value is the actual path where the vulnerability was detected 