### PR TITLE
Add vulnerability dna

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -196,23 +196,23 @@ def _compute_dna(
     return json.dumps(dna_data, sort_keys=True)
 
 
-def _sort_dict(d: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+def _sort_dict(dictionary: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
     """Recursively sort dictionary keys and lists within.
     Args:
-        d: The dictionary or list to sort.
+        dictionary: The dictionary to sort.
     Returns:
         A sorted dictionary or list.
     """
-    if isinstance(d, dict):
-        return {k: _sort_dict(v) for k, v in sorted(d.items())}
-    if isinstance(d, list):
+    if isinstance(dictionary, dict):
+        return {k: _sort_dict(v) for k, v in sorted(dictionary.items())}
+    if isinstance(dictionary, list):
         return sorted(
-            d,
+            dictionary,
             key=lambda x: json.dumps(x, sort_keys=True)
             if isinstance(x, dict)
             else str(x),
         )
-    return d
+    return dictionary
 
 
 if __name__ == "__main__":

--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -44,7 +44,7 @@ def _process_file(content: bytes) -> bytes | None:
 
 def _prepare_vulnerability_location(
     message: m.Message,
-    file_path: str,
+    file_path: str | None,
 ) -> vuln_mixin.VulnerabilityLocation | None:
     """Prepare a `VulnerabilityLocation` instance with file path as vulnerability metadata and
     iOS/Android asset & their respective bundle-ID/package name as asset metadata.
@@ -87,7 +87,7 @@ def _prepare_vulnerability_location(
         metadata.append(
             vuln_mixin.VulnerabilityLocationMetadata(
                 metadata_type=vuln_mixin.MetadataType.FILE_PATH,
-                value=file_path,
+                value=file_path or "",
             )
         )
 
@@ -124,9 +124,9 @@ class TruffleHogAgent(
 
             if path is not None:
                 technical_detail += f"""found in file `{path}`."""
-                vulnerability_location = _prepare_vulnerability_location(
-                    message=message, file_path=path
-                )
+            vulnerability_location = _prepare_vulnerability_location(
+                message=message, file_path=path
+            )
 
             if vuln.get("Verified") is True:
                 self.report_vulnerability(

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -321,7 +321,9 @@ def testTrufflehog_whenLinkdAndUnverifiedSecrets_shouldReportOnlyVerifiedVulns(
         b'"Raw":"https://admin:admin@the-internet.herokuapp.com",'
         b'"Redacted":"https://********:********@the-internet.herokuapp.com"}',
     )
+
     trufflehog_agent_file.process(msg)
+
     mocker.patch(
         "subprocess.check_output",
         return_value=b'{"Verified":false,'
@@ -347,13 +349,13 @@ def testTrufflehog_whenLogsMessageAndUnverifiedSecrets_shouldReportOnlyVerifiedV
         selector="v3.capture.logs",
         data={"message": "just a dummy logs"},
     )
-    # mocker.patch("agent.input_type_handler.get_link_type", return_value="git")
     mocker.patch(
         "subprocess.check_output",
         return_value=b'{"Verified":true,'
         b'"Raw":"https://admin:admin@the-internet.herokuapp.com",'
         b'"Redacted":"https://********:********@the-internet.herokuapp.com"}',
     )
+
     trufflehog_agent_file.process(msg)
     mocker.patch(
         "subprocess.check_output",

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -40,6 +40,10 @@ def testTruffleHog_whenFileHasFinding_reportVulnerabilities(
     trufflehog_agent_file.process(msg)
 
     assert len(agent_mock) == 1
+    assert (
+        agent_mock[0].data["dna"]
+        == '{"location": {"android_store": {"package_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "/tmp/path/file.txt"}]}, "title": "Secret information stored in the application"}'
+    )
     assert agent_mock[0].selector == "v3.report.vulnerability"
     vulnerability = agent_mock[0].data
     assert vulnerability["technical_detail"] is not None
@@ -185,6 +189,10 @@ def testTrufflehog_whenProcessingVerifiedAndUnverifiedSecrets_shouldReportOnlyVe
     trufflehog_agent_file.process(msg)
 
     assert len(agent_mock) == 1
+    assert (
+        agent_mock[0].data["dna"]
+        == '{"title": "Secret information stored in the application"}'
+    )
     assert agent_mock[0].data.get("risk_rating") == "HIGH"
     assert (
         "Secret `https://admin:admin@the-internet.herokuapp.com` found in file `magic_is_real.js`."
@@ -275,6 +283,10 @@ def testTruffleHog_whenFileHasFindingAndIosFile_reportVulnerabilitiesWithIosAsse
     trufflehog_agent_file.process(msg)
 
     assert len(agent_mock) == 1
+    assert (
+        agent_mock[0].data["dna"]
+        == '{"location": {"ios_store": {"bundle_id": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "/tmp/path/file.txt"}]}, "title": "Secret information stored in the application"}'
+    )
     assert agent_mock[0].selector == "v3.report.vulnerability"
     vulnerability = agent_mock[0].data
     assert vulnerability["technical_detail"] is not None

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -333,5 +333,5 @@ def testTrufflehog_whenLinkdAndUnverifiedSecrets_shouldReportOnlyVerifiedVulns(
     assert len(agent_mock) == 1
     assert (
         agent_mock[0].data["dna"]
-        == '{"secret_token": "https://admin:admin@the-internet.herokuapp.com", "title": "Secret information stored in the application"}'
+        == '{"location": {"domain_name": {"name": "example.com"}, "metadata": [{"type": "URL", "value": "http://example.com/test"}]}, "secret_token": "https://admin:admin@the-internet.herokuapp.com", "title": "Secret information stored in the application"}'
     )

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -42,7 +42,7 @@ def testTruffleHog_whenFileHasFinding_reportVulnerabilities(
     assert len(agent_mock) == 1
     assert (
         agent_mock[0].data["dna"]
-        == '{"location": {"android_store": {"package_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "/tmp/path/file.txt"}]}, "title": "Secret information stored in the application"}'
+        == '{"location": {"android_store": {"package_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "/tmp/path/file.txt"}]}, "secret_token": "https://admin:admin@the-internet.herokuapp.com", "title": "Secret information stored in the application"}'
     )
     assert agent_mock[0].selector == "v3.report.vulnerability"
     vulnerability = agent_mock[0].data
@@ -191,7 +191,7 @@ def testTrufflehog_whenProcessingVerifiedAndUnverifiedSecrets_shouldReportOnlyVe
     assert len(agent_mock) == 1
     assert (
         agent_mock[0].data["dna"]
-        == '{"title": "Secret information stored in the application"}'
+        == '{"secret_token": "https://admin:admin@the-internet.herokuapp.com", "title": "Secret information stored in the application"}'
     )
     assert agent_mock[0].data.get("risk_rating") == "HIGH"
     assert (
@@ -285,7 +285,7 @@ def testTruffleHog_whenFileHasFindingAndIosFile_reportVulnerabilitiesWithIosAsse
     assert len(agent_mock) == 1
     assert (
         agent_mock[0].data["dna"]
-        == '{"location": {"ios_store": {"bundle_id": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "/tmp/path/file.txt"}]}, "title": "Secret information stored in the application"}'
+        == '{"location": {"ios_store": {"bundle_id": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "/tmp/path/file.txt"}]}, "secret_token": "https://admin:admin@the-internet.herokuapp.com", "title": "Secret information stored in the application"}'
     )
     assert agent_mock[0].selector == "v3.report.vulnerability"
     vulnerability = agent_mock[0].data


### PR DESCRIPTION
The PR is part of Vuln Location/DNA stream:

- The DNA is calculated using:
    - Add a function to compute the dna  (using vuln location, vuln_title and secret)
    - Add a function to sort the dna dict
    - Updated the `report_vulnarability` to use the computed dna

PS: The vuln location was added previously https://github.com/Ostorlab/agent_trufflehog/pull/34