### PR TITLE
fix: Exclude useless paths.

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -31,6 +31,12 @@ BLACKLISTED_FILE_TYPES = [
     "irrelevant",
 ]
 
+BLACKLISTED_FILE_PATHS = [
+    "res/color",
+    "res/drawable",
+    "res/layout",
+]
+
 logging.basicConfig(
     format="%(message)s",
     datefmt="[%X]",
@@ -189,7 +195,7 @@ class TruffleHogAgent(
             path = message.data.get("path", "")
             content = message.data.get("content", b"")
             file_type = utils.get_file_type(filename=path, file_content=content)
-            if file_type in BLACKLISTED_FILE_TYPES:
+            if file_type in BLACKLISTED_FILE_TYPES or any(blacklisted_path in path for  blacklisted_path in BLACKLISTED_FILE_PATHS):
                 logger.debug(
                     "Skipping file %s with blacklisted type %s", path, file_type
                 )

--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -195,7 +195,9 @@ class TruffleHogAgent(
             path = message.data.get("path", "")
             content = message.data.get("content", b"")
             file_type = utils.get_file_type(filename=path, file_content=content)
-            if file_type in BLACKLISTED_FILE_TYPES or any(blacklisted_path in path for  blacklisted_path in BLACKLISTED_FILE_PATHS):
+            if file_type in BLACKLISTED_FILE_TYPES or any(
+                blacklisted_path in path for blacklisted_path in BLACKLISTED_FILE_PATHS
+            ):
                 logger.debug(
                     "Skipping file %s with blacklisted type %s", path, file_type
                 )

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -371,6 +371,7 @@ def testTrufflehog_whenLogsMessageAndUnverifiedSecrets_shouldReportOnlyVerifiedV
         == '{"location": {"metadata": [{"type": "LOG", "value": "just a dummy logs"}]}, "secret_token": "https://admin:admin@the-internet.herokuapp.com", "title": "Secret information stored in the application"}'
     )
 
+
 def testTruffleHog_whenFileHasBlackListedPath_skipProcessing(
     trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
     agent_persist_mock: dict[str | bytes, str | bytes],

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -370,3 +370,22 @@ def testTrufflehog_whenLogsMessageAndUnverifiedSecrets_shouldReportOnlyVerifiedV
         agent_mock[0].data["dna"]
         == '{"location": {"metadata": [{"type": "LOG", "value": "just a dummy logs"}]}, "secret_token": "https://admin:admin@the-internet.herokuapp.com", "title": "Secret information stored in the application"}'
     )
+
+def testTruffleHog_whenFileHasBlackListedPath_skipProcessing(
+    trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    agent_mock: list[message.Message],
+) -> None:
+    """Ensure that we skip blacklisted path files."""
+    msg = message.Message.from_data(
+        selector="v3.asset.file",
+        data={
+            "content": b"some file content",
+            "path": "/tmp/res/drawable/file.txt",
+            "ios_metadata": {"bundle_id": "a.b.c"},
+        },
+    )
+
+    trufflehog_agent_file.process(msg)
+
+    assert len(agent_mock) == 0


### PR DESCRIPTION
Some Android paths should not be processed since they do not contain any sensitive data but have a lot of files.