### PR TITLE
feature: add harmonyos support

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -17,6 +17,7 @@ from ostorlab.agent.mixins import agent_report_vulnerability_mixin as vuln_mixin
 from rich import logging as rich_logging
 from ostorlab.assets import ios_store
 from ostorlab.assets import android_store
+from ostorlab.assets import harmonyos_store
 from ostorlab.assets import domain_name
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.runtimes import definitions as runtime_definitions
@@ -66,10 +67,14 @@ def _prepare_vulnerability_location(
     content: bytes | None,
 ) -> vuln_mixin.VulnerabilityLocation | None:
     """Prepare a `VulnerabilityLocation` instance with file path as vulnerability metadata and
-    iOS/Android asset & their respective bundle-ID/package name as asset metadata.
+    iOS/Android/HarmonyOS asset and their respective identifiers as asset metadata.
     """
     asset: (
-        domain_name.DomainName | ios_store.IOSStore | android_store.AndroidStore | None
+        domain_name.DomainName
+        | ios_store.IOSStore
+        | android_store.AndroidStore
+        | harmonyos_store.HarmonyOSStore
+        | None
     ) = None
     metadata = []
     if message.selector == "v3.asset.link":
@@ -98,12 +103,17 @@ def _prepare_vulnerability_location(
     else:
         package_name = message.data.get("android_metadata", {}).get("package_name")
         bundle_id = message.data.get("ios_metadata", {}).get("bundle_id")
-        if bundle_id is None and package_name is None:
+        harmony_bundle_name = message.data.get("harmonyos_metadata", {}).get(
+            "bundle_name"
+        )
+        if bundle_id is None and package_name is None and harmony_bundle_name is None:
             return None
         if bundle_id is not None:
             asset = ios_store.IOSStore(bundle_id=bundle_id)
         if package_name is not None:
             asset = android_store.AndroidStore(package_name=package_name)
+        if harmony_bundle_name is not None:
+            asset = harmonyos_store.HarmonyOSStore(bundle_name=harmony_bundle_name)
 
         metadata.append(
             vuln_mixin.VulnerabilityLocationMetadata(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,18 @@ def apk_message_file() -> message.Message:
 
 
 @pytest.fixture
+def harmonyos_scan_message_file() -> message.Message:
+    """Creates a dummy message with HarmonyOS metadata for testing purposes."""
+    selector = "v3.asset.file"
+    msg_data = {
+        "content": b"some file content",
+        "path": "/tmp/path/file.txt",
+        "harmonyos_metadata": {"bundle_name": "a.b.c"},
+    }
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
 def log_contents() -> list[message.Message]:
     """Creates log content messages."""
     messages = []

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -307,6 +307,54 @@ def testTruffleHog_whenFileHasFindingAndIosFile_reportVulnerabilitiesWithIosAsse
     assert vulnerability["vulnerability_location"]["ios_store"]["bundle_id"] == "a.b.c"
 
 
+def testTruffleHog_whenFileHasFindingAndHarmonyOSFile_reportVulnerabilitiesWithHarmonyOSAssetMetadata(
+    trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
+    harmonyos_scan_message_file: message.Message,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+    agent_mock: list[message.Message],
+) -> None:
+    """Ensure the reported vulnerability contains metadata about the exact file & the HarmonyOS asset information."""
+
+    mocker.patch(
+        "subprocess.check_output",
+        return_value=b'{"SourceMetadata":{"Data":{"Git":{"commit":"77b2a3e56973785a52ba4ae4b8dac61d4bac016f",'
+        b'"file":"keys","email":"counter 003ccounter@counters-MacBook-Air.local003e",'
+        b'"repository":"https://github.com/trufflesecurity/test_keys","timestamp":"2022-06-16 10:27:56 -0700"'
+        b',"line":3}}},"SourceID":0,"SourceType":16,"SourceName":"trufflehog - git","DetectorType":17,'
+        b'"DetectorName":"URI","DecoderName":"BASE64","Verified":true,'
+        b'"Raw":"https://admin:admin@the-internet.herokuapp.com",'
+        b'"Redacted":"https://********:********@the-internet.herokuapp.com",'
+        b'"ExtraData":null,"StructuredData":null}',
+    )
+
+    trufflehog_agent_file.process(harmonyos_scan_message_file)
+
+    assert len(agent_mock) == 1
+    assert (
+        agent_mock[0].data["dna"]
+        == '{"location": {"harmonyos_store": {"bundle_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "/tmp/path/file.txt"}]}, "secret_token": "https://admin:admin@the-internet.herokuapp.com", "title": "Secret information stored in the application"}'
+    )
+    assert agent_mock[0].selector == "v3.report.vulnerability"
+    vulnerability = agent_mock[0].data
+    assert vulnerability["technical_detail"] is not None
+    assert (
+        "Secret `https://admin:admin@the-internet.herokuapp.com` of type `URI` found"
+        in vulnerability["technical_detail"]
+    )
+    assert vulnerability["risk_rating"] == "HIGH"
+    assert vulnerability["vulnerability_location"]["metadata"][0]["type"] == "FILE_PATH"
+    assert (
+        vulnerability["vulnerability_location"]["metadata"][0]["value"]
+        == "/tmp/path/file.txt"
+    )
+    assert vulnerability["vulnerability_location"]["harmonyos_store"] is not None
+    assert (
+        vulnerability["vulnerability_location"]["harmonyos_store"]["bundle_name"]
+        == "a.b.c"
+    )
+
+
 def testTrufflehog_whenLinkdAndUnverifiedSecrets_shouldReportOnlyVerifiedVulns(
     trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
     agent_persist_mock: dict[str | bytes, str | bytes],


### PR DESCRIPTION
The vulnerability location logic does not currently support the new HarmonyOS asset type.

In this PR, we add the necessary support to persist and render HarmonyOS vulnerability locations across the agent flow and related schemas, so HarmonyOS-backed findings carry the correct asset metadata. We also include tests to validate the expected behavior and ensure HarmonyOS cases are handled consistently with the existing iOS and Android paths.