### PR TITLE
feature: Add support for repository asset scanning in agent_trufflehog

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import pathlib
 import subprocess
 import tempfile
 
@@ -19,6 +20,7 @@ from ostorlab.assets import ios_store
 from ostorlab.assets import android_store
 from ostorlab.assets import harmonyos_store
 from ostorlab.assets import domain_name
+from ostorlab.assets import repository as repository_asset
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.runtimes import definitions as runtime_definitions
 
@@ -40,6 +42,7 @@ LOGS_SET_KEY = "trufflehog_logs"
 MAX_LOGS_BATCH_SIZE = 1000
 LOCK_RETRIES = 3
 LOCK_RETRY_DELAY = 2
+REPOSITORY_CODE_PATH = "/code"
 
 logging.basicConfig(
     format="%(message)s",
@@ -74,10 +77,23 @@ def _prepare_vulnerability_location(
         | ios_store.IOSStore
         | android_store.AndroidStore
         | harmonyos_store.HarmonyOSStore
+        | repository_asset.Repository
         | None
     ) = None
     metadata = []
-    if message.selector == "v3.asset.link":
+    if message.selector == "v3.asset.repository":
+        asset = repository_asset.Repository(
+            repository_url=str(message.data.get("repository_url") or ""),
+            commit_hash=str(message.data.get("commit_hash") or ""),
+        )
+        if file_path is not None:
+            metadata.append(
+                vuln_mixin.VulnerabilityLocationMetadata(
+                    metadata_type=vuln_mixin.MetadataType.FILE_PATH,
+                    value=file_path,
+                )
+            )
+    elif message.selector == "v3.asset.link":
         url = message.data.get("url")
         url_netloc = parse.urlparse(url).netloc
         asset = domain_name.DomainName(name=str(url_netloc))
@@ -126,6 +142,24 @@ def _prepare_vulnerability_location(
         asset=asset,
         metadata=metadata,
     )
+
+
+def _get_repository_file_path(vuln: dict[str, Any]) -> str | None:
+    """Extract the file path TruffleHog reports for a repository finding."""
+    source_data = vuln.get("SourceMetadata", {}).get("Data", {})
+    source_details = source_data.get("Filesystem")
+    if isinstance(source_details, dict) is False:
+        return None
+    file_path = source_details.get("file")
+    if isinstance(file_path, str) is True and file_path != "":
+        path = pathlib.Path(file_path)
+        if path.is_absolute() is True:
+            try:
+                return str(path.relative_to(REPOSITORY_CODE_PATH))
+            except ValueError:
+                return file_path
+        return file_path
+    return None
 
 
 class TruffleHogAgent(
@@ -206,6 +240,8 @@ class TruffleHogAgent(
             if secret_type is not None:
                 technical_detail += f"""of type `{secret_type}` """
             path = message.data.get("path")
+            if message.selector == "v3.asset.repository":
+                path = _get_repository_file_path(vuln)
 
             if path is not None:
                 technical_detail += f"""found in file `{path}`."""
@@ -265,6 +301,20 @@ class TruffleHogAgent(
                 return
             logger.info("Processing link %s of type %s", link, link_type)
             cmd_output = self.run_scanner(link_type, link)
+        elif message.selector == "v3.asset.repository":
+            repository_path = pathlib.Path(REPOSITORY_CODE_PATH)
+            if repository_path.is_dir() is False:
+                logger.error(
+                    "Repository path %s is not available. Ensure shared volume is mounted.",
+                    REPOSITORY_CODE_PATH,
+                )
+                return
+            logger.info(
+                "Processing repository %s from %s",
+                message.data.get("repository_url", ""),
+                REPOSITORY_CODE_PATH,
+            )
+            cmd_output = self.run_scanner("filesystem", REPOSITORY_CODE_PATH)
         elif message.selector.startswith("v3.asset.file"):
             path = message.data.get("path", "")
             content = message.data.get("content", b"")

--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -155,10 +155,10 @@ def _get_repository_file_path(vuln: dict[str, Any]) -> str | None:
         path = pathlib.Path(file_path)
         if path.is_absolute() is True:
             try:
-                return str(path.relative_to(REPOSITORY_CODE_PATH))
+                return str(path.relative_to(REPOSITORY_CODE_PATH)) or None
             except ValueError:
-                return file_path
-        return file_path
+                return str(file_path) if file_path is True else None
+        return str(file_path) if file_path is True else None
     return None
 
 

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -46,6 +46,7 @@ description: |
       ```
 in_selectors:
   - v3.asset.file
+  - v3.asset.repository
   - v3.asset.link
   - v3.capture.logs
   - v3.capture.request_response
@@ -54,3 +55,7 @@ out_selectors:
   - v3.report.vulnerability
 docker_file_path : Dockerfile # Dockerfile path for automated release build.
 docker_build_root : . # Docker build dir for automated release build.
+volumes:
+  - name: repository_code
+    path: /code
+    read_only: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,17 @@ def scan_message_gihub_without_key() -> message.Message:
 
 
 @pytest.fixture
+def repository_asset_message() -> message.Message:
+    """Creates a repository asset message for shared-volume repository scanning."""
+    selector = "v3.asset.repository"
+    msg_data = {
+        "repository_url": "https://github.com/org/repo.git",
+        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+    }
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
 def scan_message_logs() -> message.Message:
     """Creates a dummy message of type v3.capture.logs to be used by the agent for testing purposes."""
     selector = "v3.capture.logs"

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -1,6 +1,7 @@
 """Unittest for truflehog agent."""
 
 import logging
+import pathlib
 
 import pytest
 from ostorlab.agent.message import message
@@ -153,7 +154,7 @@ def testSubprocessParameter_whenProcessingRepository_beValid(
     agent_persist_mock: dict[str | bytes, str | bytes],
     mocker: plugin.MockerFixture,
     agent_mock: list[message.Message],
-    tmp_path,
+    tmp_path: pathlib.Path,
 ) -> None:
     subprocess_check_output_mock = mocker.patch(
         "subprocess.check_output", return_value=b""
@@ -468,7 +469,7 @@ def testTruffleHog_whenRepositoryHasFinding_reportVulnerabilitiesWithRepositoryM
     agent_persist_mock: dict[str | bytes, str | bytes],
     mocker: plugin.MockerFixture,
     agent_mock: list[message.Message],
-    tmp_path,
+    tmp_path: pathlib.Path,
 ) -> None:
     """Ensure repository assets emit vulnerabilities with repository location."""
     shared_code_path = tmp_path / "code"

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -147,6 +147,31 @@ def testSubprocessParameter_whenProcessingLink_beValid(
     assert args[3] == "--json"
 
 
+def testSubprocessParameter_whenProcessingRepository_beValid(
+    repository_asset_message: message.Message,
+    trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+    agent_mock: list[message.Message],
+    tmp_path,
+) -> None:
+    subprocess_check_output_mock = mocker.patch(
+        "subprocess.check_output", return_value=b""
+    )
+    shared_code_path = tmp_path / "code"
+    shared_code_path.mkdir()
+    mocker.patch("agent.trufflehog_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
+
+    trufflehog_agent_file.process(repository_asset_message)
+    args = subprocess_check_output_mock.call_args[0][0]
+
+    assert len(args) == 4
+    assert args[0] == "trufflehog"
+    assert args[1] == "filesystem"
+    assert args[2] == str(shared_code_path)
+    assert args[3] == "--json"
+
+
 def testSubprocessParameter_whenProcessingInvalidGitLink_beValid(
     trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
     agent_persist_mock: dict[str | bytes, str | bytes],
@@ -435,3 +460,43 @@ def testTruffleHog_whenFileHasBlackListedPath_skipProcessing(
     trufflehog_agent_file.process(msg)
 
     assert len(agent_mock) == 0
+
+
+def testTruffleHog_whenRepositoryHasFinding_reportVulnerabilitiesWithRepositoryMetadata(
+    trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
+    repository_asset_message: message.Message,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+    agent_mock: list[message.Message],
+    tmp_path,
+) -> None:
+    """Ensure repository assets emit vulnerabilities with repository location."""
+    shared_code_path = tmp_path / "code"
+    shared_code_path.mkdir()
+    secret_file_path = shared_code_path / "src" / "secrets.env"
+    secret_file_path.parent.mkdir()
+    secret_file_path.write_text("SECRET=value", encoding="utf-8")
+
+    mocker.patch("agent.trufflehog_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
+    mocker.patch(
+        "subprocess.check_output",
+        return_value=b'{"SourceMetadata":{"Data":{"Filesystem":{"file":"'
+        + str(secret_file_path).encode()
+        + b'"}}},"DetectorName":"URI","Verified":true,'
+        + b'"Raw":"https://admin:admin@the-internet.herokuapp.com",'
+        b'"Redacted":"https://********:********@the-internet.herokuapp.com"}',
+    )
+
+    trufflehog_agent_file.process(repository_asset_message)
+
+    assert len(agent_mock) == 1
+    assert agent_mock[0].selector == "v3.report.vulnerability"
+    vulnerability = agent_mock[0].data
+    assert vulnerability["risk_rating"] == "HIGH"
+    assert vulnerability["vulnerability_location"]["repository"] == {
+        "repository_url": "https://github.com/org/repo.git",
+        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+    }
+    assert vulnerability["vulnerability_location"]["metadata"] == [
+        {"type": "FILE_PATH", "value": "src/secrets.env"}
+    ]


### PR DESCRIPTION
**Description**

Add support for scanning `v3.asset.repository` assets in `agent_trufflehog`, so the agent can analyze source code repositories mounted in the shared `code` volume and report secrets with repository-aware vulnerability location metadata.

**Why**

Repository scans needed parity with other agents and with runtime behavior where `inject_asset` checks out the target repository into a shared volume.

This enables end-to-end repository secret detection in local scan workflows.

**What Changed**

**ostorlab.yaml**

- Added `v3.asset.repository` to `in_selectors`
- Added shared volume declaration:
  - `repository_code` mounted at `code`
  - Mounted as read-only

**agent/trufflehog_agent.py**

Implemented repository processing:
- Detect `v3.asset.repository`
- Validate that `code` exists
- Run TruffleHog using:
  - `filesystem /code --json`

Added repository-aware vulnerability location support:
- Build repository asset location using:
  - `repository_url`
  - `commit_hash`
- Attach `FILE_PATH` metadata when available

Added `_get_repository_file_path` helper:
- Extract file path from TruffleHog output:
  - `SourceMetadata.Data.Filesystem.file`
- Normalize absolute paths to repository-relative paths under `code`

**RUN SCAN TEST with a vulnerable public repository asset :** 
<img width="1556" height="630" alt="Screenshot from 2026-05-19 18-38-38" src="https://github.com/user-attachments/assets/c972cb9c-60e6-41d7-9a56-42dfe754963b" />

**LIST SCANS VULNZ:**
<img width="1561" height="654" alt="Screenshot from 2026-05-19 18-38-17" src="https://github.com/user-attachments/assets/cbd6eae0-49f3-48d5-a283-97cc033a4fa1" />
