### PR TITLE
feature: Add provider field to repository asset and update tests

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -85,6 +85,7 @@ def _prepare_vulnerability_location(
         asset = repository_asset.Repository(
             repository_url=str(message.data.get("repository_url") or ""),
             commit_hash=str(message.data.get("commit_hash") or ""),
+            provider=str(message.data.get("provider") or ""),
         )
         if file_path is not None:
             metadata.append(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ def repository_asset_message() -> message.Message:
     msg_data = {
         "repository_url": "https://github.com/org/repo.git",
         "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "provider": "GITHUB",
     }
     return message.Message.from_data(selector, data=msg_data)
 

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -497,6 +497,7 @@ def testTruffleHog_whenRepositoryHasFinding_reportVulnerabilitiesWithRepositoryM
     assert vulnerability["vulnerability_location"]["repository"] == {
         "repository_url": "https://github.com/org/repo.git",
         "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "provider": "GITHUB",
     }
     assert vulnerability["vulnerability_location"]["metadata"] == [
         {"type": "FILE_PATH", "value": "src/secrets.env"}


### PR DESCRIPTION
## Title
Preserve repository provider in TruffleHog findings

## Description
Pass the repository `provider` through when building vulnerability locations for repository scans in `agent_trufflehog`.

Also updates the repository test fixture and assertion to verify emitted findings include `provider`.