### PR TITLE
fix: remove codecov config

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,10 +39,4 @@ jobs:
           python -m uv pip install -r tests/test-requirement.txt
       - name: Running tests with pytest.
         run: |
-          pytest --cov=./ --cov-report=xml:coverage.xml --cov-report=term-missing
-      - name: Upload coverage to Codecov.
-        uses: codecov/codecov-action@v4
-        with:
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.xml
+          pytest --cov-report=term-missing

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,4 +39,4 @@ jobs:
           python -m uv pip install -r tests/test-requirement.txt
       - name: Running tests with pytest.
         run: |
-          pytest --cov-report=term-missing
+          pytest


### PR DESCRIPTION
Removes the codecov config file and the coverage upload from the pytest workflow.