### PR TITLE
feature: support v3.asset.file.repository_archive selector

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -43,6 +43,14 @@ MAX_LOGS_BATCH_SIZE = 1000
 LOCK_RETRIES = 3
 LOCK_RETRY_DELAY = 2
 REPOSITORY_CODE_PATH = "/code"
+REPOSITORY_SELECTOR = "v3.asset.repository"
+REPOSITORY_ARCHIVE_SELECTOR = "v3.asset.file.repository_archive"
+
+
+def _is_repository_selector(selector: str) -> bool:
+    """Whether the selector should be scanned as a repository from the shared `/code` volume."""
+    return selector in (REPOSITORY_SELECTOR, REPOSITORY_ARCHIVE_SELECTOR)
+
 
 logging.basicConfig(
     format="%(message)s",
@@ -81,7 +89,7 @@ def _prepare_vulnerability_location(
         | None
     ) = None
     metadata = []
-    if message.selector == "v3.asset.repository":
+    if _is_repository_selector(message.selector):
         asset = repository_asset.Repository(
             repository_url=str(message.data.get("repository_url") or ""),
             commit_hash=str(message.data.get("commit_hash") or ""),
@@ -241,7 +249,7 @@ class TruffleHogAgent(
             if secret_type is not None:
                 technical_detail += f"""of type `{secret_type}` """
             path = message.data.get("path")
-            if message.selector == "v3.asset.repository":
+            if _is_repository_selector(message.selector):
                 path = _get_repository_file_path(vuln)
 
             if path is not None:
@@ -302,7 +310,7 @@ class TruffleHogAgent(
                 return
             logger.info("Processing link %s of type %s", link, link_type)
             cmd_output = self.run_scanner(link_type, link)
-        elif message.selector == "v3.asset.repository":
+        elif _is_repository_selector(message.selector):
             repository_path = pathlib.Path(REPOSITORY_CODE_PATH)
             if repository_path.is_dir() is False:
                 logger.error(

--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -47,11 +47,6 @@ REPOSITORY_SELECTOR = "v3.asset.repository"
 REPOSITORY_ARCHIVE_SELECTOR = "v3.asset.file.repository_archive"
 
 
-def _is_repository_selector(selector: str) -> bool:
-    """Whether the selector should be scanned as a repository from the shared `/code` volume."""
-    return selector in (REPOSITORY_SELECTOR, REPOSITORY_ARCHIVE_SELECTOR)
-
-
 logging.basicConfig(
     format="%(message)s",
     datefmt="[%X]",
@@ -89,7 +84,10 @@ def _prepare_vulnerability_location(
         | None
     ) = None
     metadata = []
-    if _is_repository_selector(message.selector):
+    if (
+        message.selector == REPOSITORY_SELECTOR
+        or message.selector == REPOSITORY_ARCHIVE_SELECTOR
+    ):
         asset = repository_asset.Repository(
             repository_url=str(message.data.get("repository_url") or ""),
             commit_hash=str(message.data.get("commit_hash") or ""),
@@ -249,7 +247,10 @@ class TruffleHogAgent(
             if secret_type is not None:
                 technical_detail += f"""of type `{secret_type}` """
             path = message.data.get("path")
-            if _is_repository_selector(message.selector):
+            if (
+                message.selector == REPOSITORY_SELECTOR
+                or message.selector == REPOSITORY_ARCHIVE_SELECTOR
+            ):
                 path = _get_repository_file_path(vuln)
 
             if path is not None:
@@ -310,7 +311,10 @@ class TruffleHogAgent(
                 return
             logger.info("Processing link %s of type %s", link, link_type)
             cmd_output = self.run_scanner(link_type, link)
-        elif _is_repository_selector(message.selector):
+        elif (
+            message.selector == REPOSITORY_SELECTOR
+            or message.selector == REPOSITORY_ARCHIVE_SELECTOR
+        ):
             repository_path = pathlib.Path(REPOSITORY_CODE_PATH)
             if repository_path.is_dir() is False:
                 logger.error(

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: trufflehog
-version: 1.0.1
+version: 1.0.2
 description: |
   This repository is an implementation of [OXO Agent](https://pypi.org/project/ostorlab/) for the [trufflehog tool] https://github.com/trufflesecurity/trufflehog by trufflesecurity.
 
@@ -46,6 +46,7 @@ description: |
       ```
 in_selectors:
   - v3.asset.file
+  - v3.asset.file.repository_archive
   - v3.asset.repository
   - v3.asset.link
   - v3.capture.logs

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: trufflehog
-version: 1.0.2
+version: 1.0.1
 description: |
   This repository is an implementation of [OXO Agent](https://pypi.org/project/ostorlab/) for the [trufflehog tool] https://github.com/trufflesecurity/trufflehog by trufflesecurity.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,23 @@ def repository_asset_message() -> message.Message:
 
 
 @pytest.fixture
+def repository_archive_asset_message() -> message.Message:
+    """Creates a repository archive file asset message for shared-volume repository scanning.
+
+    The message is built directly instead of via `Message.from_data` because the
+    `v3.asset.file.repository_archive` proto is not yet shipped in `ostorlab`; the agent
+    only reads `selector` and `data`, so the raw bytes are not needed for these tests.
+    """
+    selector = "v3.asset.file.repository_archive"
+    msg_data = {
+        "repository_url": "https://github.com/org/repo.git",
+        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "provider": "GITHUB",
+    }
+    return message.Message(selector=selector, data=msg_data, raw=b"")
+
+
+@pytest.fixture
 def scan_message_logs() -> message.Message:
     """Creates a dummy message of type v3.capture.logs to be used by the agent for testing purposes."""
     selector = "v3.capture.logs"

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -502,3 +502,70 @@ def testTruffleHog_whenRepositoryHasFinding_reportVulnerabilitiesWithRepositoryM
     assert vulnerability["vulnerability_location"]["metadata"] == [
         {"type": "FILE_PATH", "value": "src/secrets.env"}
     ]
+
+
+def testSubprocessParameter_whenProcessingRepositoryArchive_beValid(
+    repository_archive_asset_message: message.Message,
+    trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+    agent_mock: list[message.Message],
+    tmp_path: pathlib.Path,
+) -> None:
+    """Ensure a repository archive asset is scanned from the shared `/code` volume."""
+    subprocess_check_output_mock = mocker.patch(
+        "subprocess.check_output", return_value=b""
+    )
+    shared_code_path = tmp_path / "code"
+    shared_code_path.mkdir()
+    mocker.patch("agent.trufflehog_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
+
+    trufflehog_agent_file.process(repository_archive_asset_message)
+    args = subprocess_check_output_mock.call_args[0][0]
+
+    assert len(args) == 4
+    assert args[0] == "trufflehog"
+    assert args[1] == "filesystem"
+    assert args[2] == str(shared_code_path)
+    assert args[3] == "--json"
+
+
+def testTruffleHog_whenRepositoryArchiveHasFinding_reportVulnerabilitiesWithRepositoryMetadata(
+    trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
+    repository_archive_asset_message: message.Message,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+    agent_mock: list[message.Message],
+    tmp_path: pathlib.Path,
+) -> None:
+    """Ensure repository archive assets emit vulnerabilities with repository location."""
+    shared_code_path = tmp_path / "code"
+    shared_code_path.mkdir()
+    secret_file_path = shared_code_path / "src" / "secrets.env"
+    secret_file_path.parent.mkdir()
+    secret_file_path.write_text("SECRET=value", encoding="utf-8")
+
+    mocker.patch("agent.trufflehog_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
+    mocker.patch(
+        "subprocess.check_output",
+        return_value=b'{"SourceMetadata":{"Data":{"Filesystem":{"file":"'
+        + str(secret_file_path).encode()
+        + b'"}}},"DetectorName":"URI","Verified":true,'
+        + b'"Raw":"https://admin:admin@the-internet.herokuapp.com",'
+        b'"Redacted":"https://********:********@the-internet.herokuapp.com"}',
+    )
+
+    trufflehog_agent_file.process(repository_archive_asset_message)
+
+    assert len(agent_mock) == 1
+    assert agent_mock[0].selector == "v3.report.vulnerability"
+    vulnerability = agent_mock[0].data
+    assert vulnerability["risk_rating"] == "HIGH"
+    assert vulnerability["vulnerability_location"]["repository"] == {
+        "repository_url": "https://github.com/org/repo.git",
+        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "provider": "GITHUB",
+    }
+    assert vulnerability["vulnerability_location"]["metadata"] == [
+        {"type": "FILE_PATH", "value": "src/secrets.env"}
+    ]


### PR DESCRIPTION
## What

Adds support for the `v3.asset.file.repository_archive` selector. When a repository archive file asset arrives, the agent handles it exactly like `v3.asset.repository`: the archived code is available on the shared `/code` volume, so the agent runs the TruffleHog `filesystem` scanner against `/code` and reports findings with a `Repository` vulnerability location and repository-relative file paths.

## Changes


  - New `_is_repository_selector` helper covering both `v3.asset.repository` and `v3.asset.file.repository_archive`.
  - Route the new selector to the repository scanning branch **before** the generic `v3.asset.file` branch (the archive selector is a `v3.asset.file` child, so ordering matters).
  - Reuse repository file-path extraction (`_get_repository_file_path`) and `Repository` location metadata for the new selector.
- `tests/`: add a `repository_archive_asset_message` fixture and two tests mirroring the existing repository tests (scanner invocation + repository vulnerability metadata).

## Notes

- The `v3.asset.file.repository_archive` proto is not yet shipped in `ostorlab`, so the test fixture constructs the `Message` directly (the agent only reads `selector` and `data`). Once the proto lands, messages deserialize normally with the unpinned `ostorlab[agent]` dependency.

