### PR TITLE
fix: repository archive vulnerability location

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -177,8 +177,8 @@ def _get_repository_file_path(vuln: dict[str, Any]) -> str | None:
             try:
                 return str(path.relative_to(REPOSITORY_CODE_PATH))
             except ValueError:
-                return file_path
-        return file_path
+                return str(file_path)
+        return str(file_path)
     return None
 
 

--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -21,6 +21,7 @@ from ostorlab.assets import android_store
 from ostorlab.assets import harmonyos_store
 from ostorlab.assets import domain_name
 from ostorlab.assets import repository as repository_asset
+from ostorlab.assets import repository_archive as repository_archive_asset
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.runtimes import definitions as runtime_definitions
 
@@ -81,13 +82,25 @@ def _prepare_vulnerability_location(
         | android_store.AndroidStore
         | harmonyos_store.HarmonyOSStore
         | repository_asset.Repository
+        | repository_archive_asset.RepositoryArchive
         | None
     ) = None
     metadata = []
-    if (
-        message.selector == REPOSITORY_SELECTOR
-        or message.selector == REPOSITORY_ARCHIVE_SELECTOR
-    ):
+    if message.selector == REPOSITORY_ARCHIVE_SELECTOR:
+        content_url = message.data.get("content_url")
+        if content_url is None:
+            return None
+        asset = repository_archive_asset.RepositoryArchive(
+            content_url=str(content_url),
+        )
+        if file_path is not None:
+            metadata.append(
+                vuln_mixin.VulnerabilityLocationMetadata(
+                    metadata_type=vuln_mixin.MetadataType.FILE_PATH,
+                    value=file_path,
+                )
+            )
+    elif message.selector == REPOSITORY_SELECTOR:
         asset = repository_asset.Repository(
             repository_url=str(message.data.get("repository_url") or ""),
             commit_hash=str(message.data.get("commit_hash") or ""),
@@ -162,10 +175,10 @@ def _get_repository_file_path(vuln: dict[str, Any]) -> str | None:
         path = pathlib.Path(file_path)
         if path.is_absolute() is True:
             try:
-                return str(path.relative_to(REPOSITORY_CODE_PATH)) or None
+                return str(path.relative_to(REPOSITORY_CODE_PATH))
             except ValueError:
-                return str(file_path) if file_path is True else None
-        return str(file_path) if file_path is True else None
+                return file_path
+        return file_path
     return None
 
 
@@ -323,8 +336,8 @@ class TruffleHogAgent(
                 )
                 return
             logger.info(
-                "Processing repository %s from %s",
-                message.data.get("repository_url", ""),
+                "Processing %s asset from %s",
+                message.selector,
                 REPOSITORY_CODE_PATH,
             )
             cmd_output = self.run_scanner("filesystem", REPOSITORY_CODE_PATH)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,19 +44,17 @@ def repository_asset_message() -> message.Message:
 
 @pytest.fixture
 def repository_archive_asset_message() -> message.Message:
-    """Creates a repository archive file asset message for shared-volume repository scanning.
-
-    The message is built directly instead of via `Message.from_data` because the
-    `v3.asset.file.repository_archive` proto is not yet shipped in `ostorlab`; the agent
-    only reads `selector` and `data`, so the raw bytes are not needed for these tests.
-    """
+    """Creates a repository archive asset message for shared-volume repository scanning."""
     selector = "v3.asset.file.repository_archive"
-    msg_data = {
-        "repository_url": "https://github.com/org/repo.git",
-        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
-        "provider": "GITHUB",
-    }
-    return message.Message(selector=selector, data=msg_data, raw=b"")
+    msg_data = {"content_url": "https://github.com/org/repo/archive/main.zip"}
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
+def repository_archive_asset_message_without_content_url() -> message.Message:
+    """Creates a malformed repository archive asset message, missing its `content_url`."""
+    selector = "v3.asset.file.repository_archive"
+    return message.Message.from_data(selector, data={})
 
 
 @pytest.fixture

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -530,7 +530,7 @@ def testSubprocessParameter_whenProcessingRepositoryArchive_beValid(
     assert args[3] == "--json"
 
 
-def testTruffleHog_whenRepositoryArchiveHasFinding_reportVulnerabilitiesWithRepositoryMetadata(
+def testTruffleHog_whenRepositoryArchiveHasFinding_reportVulnerabilitiesWithRepositoryArchiveMetadata(
     trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
     repository_archive_asset_message: message.Message,
     agent_persist_mock: dict[str | bytes, str | bytes],
@@ -538,7 +538,7 @@ def testTruffleHog_whenRepositoryArchiveHasFinding_reportVulnerabilitiesWithRepo
     agent_mock: list[message.Message],
     tmp_path: pathlib.Path,
 ) -> None:
-    """Ensure repository archive assets emit vulnerabilities with repository location."""
+    """Ensure repository archive assets emit vulnerabilities with a repository archive location."""
     shared_code_path = tmp_path / "code"
     shared_code_path.mkdir()
     secret_file_path = shared_code_path / "src" / "secrets.env"
@@ -561,11 +561,42 @@ def testTruffleHog_whenRepositoryArchiveHasFinding_reportVulnerabilitiesWithRepo
     assert agent_mock[0].selector == "v3.report.vulnerability"
     vulnerability = agent_mock[0].data
     assert vulnerability["risk_rating"] == "HIGH"
-    assert vulnerability["vulnerability_location"]["repository"] == {
-        "repository_url": "https://github.com/org/repo.git",
-        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
-        "provider": "GITHUB",
+    assert vulnerability["vulnerability_location"]["repository_archive"] == {
+        "content_url": "https://github.com/org/repo/archive/main.zip"
     }
+    assert vulnerability["vulnerability_location"].get("repository") is None
     assert vulnerability["vulnerability_location"]["metadata"] == [
         {"type": "FILE_PATH", "value": "src/secrets.env"}
     ]
+
+
+def testTruffleHog_whenRepositoryArchiveHasNoContentUrl_reportVulnerabilitiesWithoutLocation(
+    trufflehog_agent_file: trufflehog_agent.TruffleHogAgent,
+    repository_archive_asset_message_without_content_url: message.Message,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+    agent_mock: list[message.Message],
+    tmp_path: pathlib.Path,
+) -> None:
+    """A malformed archive message without a `content_url` cannot identify the asset, the secret is
+    still reported but with no vulnerability location."""
+    shared_code_path = tmp_path / "code"
+    shared_code_path.mkdir()
+    secret_file_path = shared_code_path / "src" / "secrets.env"
+    secret_file_path.parent.mkdir()
+    secret_file_path.write_text("SECRET=value", encoding="utf-8")
+
+    mocker.patch("agent.trufflehog_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
+    mocker.patch(
+        "subprocess.check_output",
+        return_value=b'{"SourceMetadata":{"Data":{"Filesystem":{"file":"'
+        + str(secret_file_path).encode()
+        + b'"}}},"DetectorName":"URI","Verified":true,'
+        + b'"Raw":"https://admin:admin@the-internet.herokuapp.com",'
+        b'"Redacted":"https://********:********@the-internet.herokuapp.com"}',
+    )
+
+    trufflehog_agent_file.process(repository_archive_asset_message_without_content_url)
+
+    assert len(agent_mock) == 1
+    assert agent_mock[0].data.get("vulnerability_location") is None


### PR DESCRIPTION
The `v3.asset.file.repository_archive` proto carries `content`, `path` and `content_url`:

```proto
message Message {
  optional bytes content = 1;
  optional string path = 2;
  optional string content_url = 3;
}
```

It does not carry `repository_url`, `commit_hash` or `provider`. #52 nonetheless built a `Repository` vulnerability location out of those three fields for archive assets, so every archive finding was reported against an empty `repository` asset (`{"repository_url": "", "commit_hash": ""}`) — the wrong asset type, with no identifying data.