### PR TITLE
feature: exclude paths

### DIFF
--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -343,7 +343,10 @@ class TruffleHogAgent(
             cmd_output = self.run_scanner("filesystem", REPOSITORY_CODE_PATH)
         elif message.selector.startswith("v3.asset.file"):
             path = message.data.get("path", "")
-            if utils.should_exclude_path(path, self.args.get("exclude_paths")) is True:
+            if (
+                utils.should_exclude_path(path, self.args.get("exclude_path_regexes"))
+                is True
+            ):
                 return
             content = message.data.get("content", b"")
             file_type = utils.get_file_type(filename=path, file_content=content)

--- a/agent/trufflehog_agent.py
+++ b/agent/trufflehog_agent.py
@@ -343,6 +343,8 @@ class TruffleHogAgent(
             cmd_output = self.run_scanner("filesystem", REPOSITORY_CODE_PATH)
         elif message.selector.startswith("v3.asset.file"):
             path = message.data.get("path", "")
+            if utils.should_exclude_path(path, self.args.get("exclude_paths")) is True:
+                return
             content = message.data.get("content", b"")
             file_type = utils.get_file_type(filename=path, file_content=content)
             if file_type in BLACKLISTED_FILE_TYPES:

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -10,24 +10,26 @@ import magic
 logger = logging.getLogger(__name__)
 
 
-def should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
+def should_exclude_path(
+    path: str | None, exclude_path_regexes: list[str] | None
+) -> bool:
     """Report whether a file path matches one of the exclusion regex patterns.
 
     Args:
         path: The file path reported in the message, or None.
-        exclude_paths: List of regex patterns to match against the path.
+        exclude_path_regexes: List of regex patterns to match against the path.
 
     Returns:
         True if the path matches at least one pattern and should be skipped,
         False otherwise.
     """
-    if path is None or exclude_paths is None or len(exclude_paths) == 0:
+    if path is None or exclude_path_regexes is None or len(exclude_path_regexes) == 0:
         return False
-    for pattern in exclude_paths:
+    for pattern in exclude_path_regexes:
         try:
             matched = re.search(pattern, path)
         except re.error as e:
-            logger.warning("Invalid exclude_paths regex %r: %s", pattern, e)
+            logger.warning("Invalid exclude_path_regexes regex %r: %s", pattern, e)
             continue
         if matched is not None:
             logger.info(

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -1,9 +1,35 @@
 """Helper functions for the Trufflehog agent"""
 
 import json
+import logging
 from typing import Any
 
 import magic
+
+logger = logging.getLogger(__name__)
+
+
+def should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
+    """Report whether a file path starts with one of the excluded prefixes.
+
+    Args:
+        path: The file path reported in the message, or None.
+        exclude_paths: List of path prefixes to match against the path.
+
+    Returns:
+        True if the path starts with at least one prefix and should be skipped,
+        False otherwise.
+    """
+    if path is None or exclude_paths is None or len(exclude_paths) == 0:
+        return False
+    for prefix in exclude_paths:
+        if path.startswith(prefix) is True:
+            logger.info(
+                "Skipping file %s: path matches exclude prefix %r.", path, prefix
+            )
+            return True
+    return False
+
 
 IRRELEVANT_FILE_PATHS = [
     "res/color",

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 from typing import Any
 
 import magic
@@ -10,22 +11,27 @@ logger = logging.getLogger(__name__)
 
 
 def should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
-    """Report whether a file path starts with one of the excluded prefixes.
+    """Report whether a file path matches one of the exclusion regex patterns.
 
     Args:
         path: The file path reported in the message, or None.
-        exclude_paths: List of path prefixes to match against the path.
+        exclude_paths: List of regex patterns to match against the path.
 
     Returns:
-        True if the path starts with at least one prefix and should be skipped,
+        True if the path matches at least one pattern and should be skipped,
         False otherwise.
     """
     if path is None or exclude_paths is None or len(exclude_paths) == 0:
         return False
-    for prefix in exclude_paths:
-        if path.startswith(prefix) is True:
+    for pattern in exclude_paths:
+        try:
+            matched = re.search(pattern, path)
+        except re.error as e:
+            logger.warning("Invalid exclude_paths regex %r: %s", pattern, e)
+            continue
+        if matched is not None:
             logger.info(
-                "Skipping file %s: path matches exclude prefix %r.", path, prefix
+                "Skipping file %s: path matches exclude pattern %r.", path, pattern
             )
             return True
     return False

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -54,6 +54,10 @@ in_selectors:
   - v3.report.event.scan.done
 out_selectors:
   - v3.report.vulnerability
+args:
+  - name: "exclude_paths"
+    type: "array"
+    description: "List of regex patterns; files whose path matches any pattern are skipped."
 docker_file_path : Dockerfile # Dockerfile path for automated release build.
 docker_build_root : . # Docker build dir for automated release build.
 volumes:

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -55,7 +55,7 @@ in_selectors:
 out_selectors:
   - v3.report.vulnerability
 args:
-  - name: "exclude_paths"
+  - name: "exclude_path_regexes"
     type: "array"
     description: "List of regex patterns; files whose path matches any pattern are skipped."
 docker_file_path : Dockerfile # Dockerfile path for automated release build.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,10 +126,10 @@ def trufflehog_agent_file_with_exclude_paths(
             bus_url="NA",
             bus_exchange_topic="NA",
             args=[
-                utils_definitions.Arg.build(
+                utils_definitions.Arg(
                     name="exclude_paths",
                     type="array",
-                    value=json.dumps([r"^/workspace(/|$)"]),
+                    value=json.dumps([r"^/workspace(/|$)"]).encode(),
                 )
             ],
             healthcheck_port=random.randint(5000, 6000),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,31 @@ def trufflehog_agent_file(
     return agent_object
 
 
+@pytest.fixture()
+def trufflehog_agent_file_with_exclude_paths(
+    agent_persist_mock: Dict[str | bytes, str | bytes],
+) -> trufflehog_agent.TruffleHogAgent:
+    """TruffleHog agent configured to exclude files under /workspace."""
+    with (pathlib.Path(__file__).parent.parent / "ostorlab.yaml").open() as yaml_o:
+        definition = agent_definitions.AgentDefinition.from_yaml(yaml_o)
+        settings = runtime_definitions.AgentSettings(
+            key="agent/ostorlab/trufflehog",
+            bus_url="NA",
+            bus_exchange_topic="NA",
+            args=[
+                {
+                    "name": "exclude_paths",
+                    "type": "array",
+                    "value": [r"^/workspace(/|$)"],
+                }
+            ],
+            healthcheck_port=random.randint(5000, 6000),
+            redis_url="redis://guest:guest@localhost:6379",
+        )
+        agent_object = trufflehog_agent.TruffleHogAgent(definition, settings)
+    return agent_object
+
+
 @pytest.fixture
 def apk_message_file() -> message.Message:
     """Creates a dummy message of type v3.asset.file that wraps an apk file."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 conftest for trufflehog agent tests
 """
 
+import json
 import pytest
 import random
 import pathlib
@@ -10,6 +11,7 @@ from typing import Dict
 from ostorlab.agent.message import message
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.runtimes import definitions as runtime_definitions
+from ostorlab.utils import definitions as utils_definitions
 from agent import trufflehog_agent
 
 
@@ -124,11 +126,11 @@ def trufflehog_agent_file_with_exclude_paths(
             bus_url="NA",
             bus_exchange_topic="NA",
             args=[
-                {
-                    "name": "exclude_paths",
-                    "type": "array",
-                    "value": [r"^/workspace(/|$)"],
-                }
+                utils_definitions.Arg.build(
+                    name="exclude_paths",
+                    type="array",
+                    value=json.dumps([r"^/workspace(/|$)"]),
+                )
             ],
             healthcheck_port=random.randint(5000, 6000),
             redis_url="redis://guest:guest@localhost:6379",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def trufflehog_agent_file(
 
 
 @pytest.fixture()
-def trufflehog_agent_file_with_exclude_paths(
+def trufflehog_agent_file_with_exclude_path_regexes(
     agent_persist_mock: Dict[str | bytes, str | bytes],
 ) -> trufflehog_agent.TruffleHogAgent:
     """TruffleHog agent configured to exclude files under /workspace."""
@@ -127,7 +127,7 @@ def trufflehog_agent_file_with_exclude_paths(
             bus_exchange_topic="NA",
             args=[
                 utils_definitions.Arg(
-                    name="exclude_paths",
+                    name="exclude_path_regexes",
                     type="array",
                     value=json.dumps([r"^/workspace(/|$)"]).encode(),
                 )

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -600,3 +600,22 @@ def testTruffleHog_whenRepositoryArchiveHasNoContentUrl_reportVulnerabilitiesWit
 
     assert len(agent_mock) == 1
     assert agent_mock[0].data.get("vulnerability_location") is None
+
+
+def testTruffleHog_whenFilePathIsExcluded_notProcessMessage(
+    trufflehog_agent_file_with_exclude_paths: trufflehog_agent.TruffleHogAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+    agent_mock: list[message.Message],
+) -> None:
+    """A file whose path matches an exclude pattern is skipped: no scan, no emitted message."""
+    subprocess_mock = mocker.patch("subprocess.check_output")
+    msg = message.Message.from_data(
+        selector="v3.asset.file",
+        data={"content": b"some file content", "path": "/workspace/file.txt"},
+    )
+
+    trufflehog_agent_file_with_exclude_paths.process(msg)
+
+    assert subprocess_mock.call_count == 0
+    assert len(agent_mock) == 0

--- a/tests/trufflehog_test.py
+++ b/tests/trufflehog_test.py
@@ -603,7 +603,7 @@ def testTruffleHog_whenRepositoryArchiveHasNoContentUrl_reportVulnerabilitiesWit
 
 
 def testTruffleHog_whenFilePathIsExcluded_notProcessMessage(
-    trufflehog_agent_file_with_exclude_paths: trufflehog_agent.TruffleHogAgent,
+    trufflehog_agent_file_with_exclude_path_regexes: trufflehog_agent.TruffleHogAgent,
     agent_persist_mock: dict[str | bytes, str | bytes],
     mocker: plugin.MockerFixture,
     agent_mock: list[message.Message],
@@ -615,7 +615,25 @@ def testTruffleHog_whenFilePathIsExcluded_notProcessMessage(
         data={"content": b"some file content", "path": "/workspace/file.txt"},
     )
 
-    trufflehog_agent_file_with_exclude_paths.process(msg)
+    trufflehog_agent_file_with_exclude_path_regexes.process(msg)
 
     assert subprocess_mock.call_count == 0
     assert len(agent_mock) == 0
+
+
+def testTruffleHog_whenFilePathIsNotExcluded_processMessage(
+    trufflehog_agent_file_with_exclude_path_regexes: trufflehog_agent.TruffleHogAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+    agent_mock: list[message.Message],
+) -> None:
+    """A file whose path does not match any exclude pattern is scanned normally."""
+    subprocess_mock = mocker.patch("subprocess.check_output", return_value=b"")
+    msg = message.Message.from_data(
+        selector="v3.asset.file",
+        data={"content": b"some file content", "path": "/tmp/file.txt"},
+    )
+
+    trufflehog_agent_file_with_exclude_path_regexes.process(msg)
+
+    assert subprocess_mock.call_count == 1

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -141,3 +141,63 @@ def testGetFileType_always_detectTheCorrectType(
     path: str, content: bytes, type: str
 ) -> None:
     assert utils.get_file_type(path, content) == type
+
+
+def testShouldExcludePath_whenPathMatchesPattern_shouldReturnTrue() -> None:
+    """A path matching an exclude pattern returns True."""
+    result = utils.should_exclude_path("/workspace/src/main.py", [r"^/workspace(/|$)"])
+
+    assert result is True
+
+
+def testShouldExcludePath_whenPathDoesNotMatch_shouldReturnFalse() -> None:
+    """A path not matching any pattern returns False."""
+    result = utils.should_exclude_path("/tmp/main.py", [r"^/workspace(/|$)"])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenSimilarPrefixNotUnderWorkspace_shouldReturnFalse() -> (
+    None
+):
+    """A lookalike path is not excluded by the anchored pattern."""
+    result = utils.should_exclude_path("/workspace_backup/a.py", [r"^/workspace(/|$)"])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenLaterPatternMatches_shouldReturnTrue() -> None:
+    """A match on any pattern in the list returns True."""
+    result = utils.should_exclude_path(
+        "/private/a.py", [r"^/workspace(/|$)", r"^/private(/|$)"]
+    )
+
+    assert result is True
+
+
+def testShouldExcludePath_whenPathIsNone_shouldReturnFalse() -> None:
+    """A None path is never excluded."""
+    result = utils.should_exclude_path(None, [r"^/workspace(/|$)"])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenExcludePathsIsEmpty_shouldReturnFalse() -> None:
+    """An empty pattern list excludes nothing."""
+    result = utils.should_exclude_path("/workspace/a.py", [])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenExcludePathsIsNone_shouldReturnFalse() -> None:
+    """A None pattern list excludes nothing."""
+    result = utils.should_exclude_path("/workspace/a.py", None)
+
+    assert result is False
+
+
+def testShouldExcludePath_whenRegexIsInvalid_shouldSkipPatternAndReturnFalse() -> None:
+    """An invalid regex pattern is skipped instead of raising."""
+    result = utils.should_exclude_path("/workspace/a.py", ["[invalid("])
+
+    assert result is False


### PR DESCRIPTION
# Add exclude_path_regexes arg to skip files by regex pattern

Adds a new `exclude_path_regexes` arg (list of regex patterns). When a `v3.asset.file` message has a path that matches one of the patterns, the agent logs and skips the file instead of scanning it.

- New `exclude_path_regexes` arg in `ostorlab.yaml`.
- File processing skips any path matching an excluded pattern.
